### PR TITLE
fix: make sure PKG_VARDIR is created before usermod

### DIFF
--- a/cbuild/share/templates/cbuild/packaging/deb/__PRJ_BUILDDIR__/packaging/debian/__PKG_NAME__-common.postinst.tmpl
+++ b/cbuild/share/templates/cbuild/packaging/deb/__PRJ_BUILDDIR__/packaging/debian/__PKG_NAME__-common.postinst.tmpl
@@ -22,6 +22,11 @@ function make_dir() {
 }
 
 if [ "$1" = "configure" ]; then
+    # Create system directories and fix permissions
+    make_dir %{ ${PKG_VARDIR} }%
+    make_dir %{ ${PKG_LOGDIR} }%
+    make_dir %{ ${PKG_RUNDIR} }%
+
 %     if [ $PRJ_USER != "root" ]; then
     if [ -z "$2" ]; then
         # Install
@@ -39,10 +44,6 @@ if [ "$1" = "configure" ]; then
     fi
 
 %     fi
-    # Create system directories and fix permissions
-    make_dir %{ ${PKG_VARDIR} }%
-    make_dir %{ ${PKG_LOGDIR} }%
-    make_dir %{ ${PKG_RUNDIR} }%
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Fixes usermod invocation on a non-existant directory

Setting up copernic-common (1.4.2+jessie1) ...
creating expand system user
usermod: user '/var/lib/copernic' does not exist
dpkg: error processing package copernic-common (--install):